### PR TITLE
add encoding='utf-8' in open() (base.py)

### DIFF
--- a/augmentex/base.py
+++ b/augmentex/base.py
@@ -45,7 +45,7 @@ class BaseAug(ABC):
         Returns:
             Dict: dict with data.
         """
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             data = json.load(f)
 
         return data


### PR DESCRIPTION
Without this change, the `WordAug` and `CharAug` objects are not created on my computer.

![image](https://github.com/ai-forever/augmentex/assets/74362240/a89101d9-1b16-4a62-a748-595f790020f2)
